### PR TITLE
Update shared_preferences pubspec constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: ^0.5.0
+  shared_preferences: '>=0.5.0 <2.0.0'
   meta: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
From here: https://pub.dev/packages/shared_preferences#backward-compatible-100-version-is-coming  
Backward compatible 1.0.0 version is coming.  
The plugin has reached a stable API, we guarantee that version 1.0.0 will be backward compatible with 0.5.y+z. Please use shared_preferences: '>=0.5.y+x <2.0.0' as your dependency constraint to allow a smoother ecosystem migration. For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0.