### PR TITLE
Migrate to null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0
+* [#16](https://github.com/roughike/streaming_shared_preferences/pull/16): Migrate to null-safety
+
+**Breaking changes:**
+
+* As in the null-safe version of [<kbd>shared_preferences</kbd>](https://pub.dev/packages/shared_preferences/changelog#200), setters no longer accept `null` to mean removing values. If you were previously using `set*(key, null)` for removing, use `remove(key)` instead.
+
 ## 1.0.2
 * [#7](https://github.com/roughike/streaming_shared_preferences/pull/7): Loosen constraints on `shared_preferences` dependency
 * [#10](https://github.com/roughike/streaming_shared_preferences/pull/10): Add `WidgetsFlutterBinding.ensureInitialize()` to README and example project

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you're already using `shared_preferences`, **you should replace the dependenc
 
 ```yaml
 dependencies:
-  streaming_shared_preferences: ^1.0.1
+  streaming_shared_preferences: ^2.0.0
 ```
 
 To get a hold of `StreamingSharedPreferences`, _await_ on `instance`:
@@ -244,7 +244,7 @@ final sampleObject = preferences.getCustomValue<SampleObject>(
 );
 ```
 
-Depending on your use case, you need to provided a non-null `SampleObject.empty()` that represents a sane default for your custom type when the value is not loaded just yet.
+Depending on your use case, you need to provide a non-null `SampleObject.empty()` that represents a sane default for your custom type when the value is not loaded just yet.
 
 ### Using JsonAdapter with built_value
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -37,8 +37,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.example"
+        applicationId "dev.iiro.streaming_shared_preferences.example"
         minSdkVersion 16
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+    package="dev.iiro.streaming_shared_preferences.example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,16 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+    package="dev.iiro.streaming_shared_preferences.example">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
-    <application
-        android:name="io.flutter.app.FlutterApplication"
+    <application android:name="io.flutter.app.FlutterApplication"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
-        <activity
-            android:name=".MainActivity"
+        <activity android:name=".MainActivity"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
@@ -23,8 +21,7 @@
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
-        <meta-data
-            android:name="flutterEmbedding"
+        <meta-data android:name="flutterEmbedding"
             android:value="2" />
     </application>
 </manifest>

--- a/example/android/app/src/main/kotlin/dev/iiro/streaming_shared_preferences/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/dev/iiro/streaming_shared_preferences/example/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.example
+package dev.iiro.streaming_shared_preferences.example
 
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity

--- a/example/android/app/src/profile/AndroidManifest.xml
+++ b/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+    package="dev.iiro.streaming_shared_preferences.example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,7 +96,7 @@ class MyHomePage extends StatelessWidget {
               builder: (BuildContext context, int counter) {
                 return Text(
                   '$counter',
-                  style: Theme.of(context).textTheme.display1,
+                  style: Theme.of(context).textTheme.headline4,
                 );
               },
             ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,18 +1,14 @@
-name: example
-description: A new Flutter project.
-version: 1.0.0+1
+name: streaming_shared_preferences_example
+description: An example project for streaming_shared_preferences.
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
+publish_to: 'none'
 
 dependencies:
   flutter:
     sdk: flutter
   streaming_shared_preferences:
     path: ../
-
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/lib/src/adapters/datetime_adapter.dart
+++ b/lib/src/adapters/datetime_adapter.dart
@@ -2,15 +2,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'preference_adapter.dart';
 
-/// A [PreferenceAdapter] implementation for storing and retrieving a [DateTime].
+/// A [PreferenceAdapter] implementation for storing and retrieving a
+/// [DateTime].
 ///
-/// Stores values as timezone independent milliseconds from the standard Unix epoch.
+/// Stores values as timezone independent milliseconds from the standard Unix
+/// epoch.
 class DateTimeAdapter extends PreferenceAdapter<DateTime> {
   static const instance = DateTimeAdapter._();
   const DateTimeAdapter._();
 
   @override
-  DateTime getValue(SharedPreferences preferences, String key) {
+  DateTime? getValue(SharedPreferences preferences, String key) {
     final value = preferences.getString(key);
     if (value == null) return null;
 
@@ -19,10 +21,10 @@ class DateTimeAdapter extends PreferenceAdapter<DateTime> {
 
   @override
   Future<bool> setValue(
-      SharedPreferences preferences, String key, DateTime value) {
-    return preferences.setString(
-      key,
-      value?.millisecondsSinceEpoch?.toString(),
-    );
+    SharedPreferences preferences,
+    String key,
+    DateTime value,
+  ) {
+    return preferences.setString(key, value.millisecondsSinceEpoch.toString());
   }
 }

--- a/lib/src/adapters/json_adapter.dart
+++ b/lib/src/adapters/json_adapter.dart
@@ -4,11 +4,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'preference_adapter.dart';
 
-/// A convenience adapter that handles common pitfalls when storing and retrieving
-/// JSON values.
+/// A convenience adapter that handles common pitfalls when storing and
+/// retrieving JSON values.
 ///
 /// [JsonAdapter] eliminates the need for a custom [PreferenceAdapter]. It also
-/// saves you from duplicating `if (value == null) return null` for custom adapters.
+/// saves you from duplicating `if (value == null) return null` for custom
+/// adapters.
 ///
 /// For example, if we have a class called `SampleObject`:
 ///
@@ -58,21 +59,21 @@ import 'preference_adapter.dart';
 /// ```
 class JsonAdapter<T> extends PreferenceAdapter<T> {
   const JsonAdapter({this.serializer, this.deserializer});
-  final Object Function(T) serializer;
-  final T Function(Object) deserializer;
+  final Object Function(T)? serializer;
+  final T Function(Object)? deserializer;
 
   @override
-  T getValue(SharedPreferences preferences, String key) {
+  T? getValue(SharedPreferences preferences, String key) {
     final value = preferences.getString(key);
     if (value == null) return null;
 
     final decoded = jsonDecode(value);
-    return deserializer != null ? deserializer(decoded) : decoded;
+    return deserializer != null ? deserializer!(decoded) : decoded;
   }
 
   @override
   Future<bool> setValue(SharedPreferences preferences, String key, T value) {
-    final serializedValue = serializer != null ? serializer(value) : value;
+    final serializedValue = serializer != null ? serializer!(value) : value;
     return preferences.setString(key, jsonEncode(serializedValue));
   }
 }

--- a/lib/src/adapters/preference_adapter.dart
+++ b/lib/src/adapters/preference_adapter.dart
@@ -10,10 +10,10 @@ abstract class PreferenceAdapter<T> {
   const PreferenceAdapter();
 
   /// Retrieve a value associated with the [key] by using the [preferences].
-  T getValue(SharedPreferences preferences, String key);
+  T? getValue(SharedPreferences preferences, String key);
 
   /// Set a [value] for the [key] by using the [preferences].
   ///
-  /// Returns true if value was successfully set, otherwise false.
+  /// Returns `true` if value was successfully set, otherwise `false`.
   Future<bool> setValue(SharedPreferences preferences, String key, T value);
 }

--- a/lib/src/adapters/primitive_adapters.dart
+++ b/lib/src/adapters/primitive_adapters.dart
@@ -6,7 +6,7 @@ class BoolAdapter extends PreferenceAdapter<bool> {
   const BoolAdapter._();
 
   @override
-  bool getValue(preferences, key) => preferences.getBool(key);
+  bool? getValue(preferences, key) => preferences.getBool(key);
 
   @override
   Future<bool> setValue(preferences, key, value) =>
@@ -19,7 +19,7 @@ class IntAdapter extends PreferenceAdapter<int> {
   const IntAdapter._();
 
   @override
-  int getValue(preferences, key) => preferences.getInt(key);
+  int? getValue(preferences, key) => preferences.getInt(key);
 
   @override
   Future<bool> setValue(preferences, key, value) =>
@@ -32,7 +32,7 @@ class DoubleAdapter extends PreferenceAdapter<double> {
   const DoubleAdapter._();
 
   @override
-  double getValue(preferences, key) => preferences.getDouble(key);
+  double? getValue(preferences, key) => preferences.getDouble(key);
 
   @override
   Future<bool> setValue(preferences, key, value) =>
@@ -45,7 +45,7 @@ class StringAdapter extends PreferenceAdapter<String> {
   const StringAdapter._();
 
   @override
-  String getValue(preferences, key) => preferences.getString(key);
+  String? getValue(preferences, key) => preferences.getString(key);
 
   @override
   Future<bool> setValue(preferences, key, value) =>
@@ -59,7 +59,7 @@ class StringListAdapter extends PreferenceAdapter<List<String>> {
   const StringListAdapter._();
 
   @override
-  List<String> getValue(preferences, key) => preferences.getStringList(key);
+  List<String>? getValue(preferences, key) => preferences.getStringList(key);
 
   @override
   Future<bool> setValue(preferences, key, values) =>

--- a/lib/src/preference/preference_builder.dart
+++ b/lib/src/preference/preference_builder.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../preference/preference.dart';
@@ -21,10 +20,9 @@ typedef PreferenceWidgetBuilder<T> = Function(BuildContext context, T value);
 /// will not be called as it would be unnecessary to do so.
 class PreferenceBuilder<T> extends StatefulWidget {
   PreferenceBuilder({
-    @required this.preference,
-    @required this.builder,
-  })  : assert(preference != null, 'Preference must not be null.'),
-        assert(builder != null, 'PreferenceWidgetBuilder must not be null.');
+    required this.preference,
+    required this.builder,
+  });
 
   /// The preference on which you want to react and rebuild your widgets based on.
   final Preference<T> preference;
@@ -37,8 +35,8 @@ class PreferenceBuilder<T> extends StatefulWidget {
 }
 
 class _PreferenceBuilderState<T> extends State<PreferenceBuilder<T>> {
-  T _initialData;
-  Stream<T> _preference;
+  late final T _initialData;
+  late final Stream<T> _preference;
 
   @override
   void initState() {
@@ -53,7 +51,7 @@ class _PreferenceBuilderState<T> extends State<PreferenceBuilder<T>> {
     return StreamBuilder<T>(
       initialData: _initialData,
       stream: _preference,
-      builder: (context, snapshot) => widget.builder(context, snapshot.data),
+      builder: (context, snapshot) => widget.builder(context, snapshot.data!),
     );
   }
 }
@@ -67,10 +65,10 @@ class _EmitOnlyChangedValues<T> extends StreamTransformerBase<T, T> {
   @override
   Stream<T> bind(Stream<T> stream) {
     return StreamTransformer<T, T>((input, cancelOnError) {
-      T lastValue = startValue;
+      T? lastValue = startValue;
 
-      StreamController<T> controller;
-      StreamSubscription<T> subscription;
+      late final StreamController<T> controller;
+      late final StreamSubscription<T> subscription;
 
       controller = StreamController<T>(
         sync: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: streaming_shared_preferences
 description: A stream based wrapper over shared_preferences, allowing reactive key-value storage.
-version: 1.0.2
+version: 2.0.0
 homepage: https://github.com/roughike/streaming_shared_preferences
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: '>=0.5.0 <2.0.0'
-  meta: ^1.0.0
+  meta: ^1.3.0
+  shared_preferences: ^2.0.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mockito: ^5.0.0
   test: ^1.0.0
-  mockito: ^4.0.0

--- a/test/adapters/datetime_adapter_test.dart
+++ b/test/adapters/datetime_adapter_test.dart
@@ -3,23 +3,32 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 import 'package:test/test.dart';
 
-class MockSharedPreferences extends Mock implements SharedPreferences {}
+class MockSharedPreferences extends Mock implements SharedPreferences {
+  @override
+  Future<bool> setString(String key, String? value) {
+    return super.noSuchMethod(
+      Invocation.method(#setString, [key, value]),
+      returnValue: Future.value(true),
+      returnValueForMissingStub: Future.value(true),
+    );
+  }
+}
 
 void main() {
   group('DateTimeAdapter', () {
-    MockSharedPreferences preferences;
+    late MockSharedPreferences preferences;
 
     setUp(() {
       preferences = MockSharedPreferences();
     });
 
     final adapter = DateTimeAdapter.instance;
-    final dateTime = DateTime(2019, 01, 02, 03, 04, 05, 99).toUtc();
+    final dateTime = DateTime.utc(2019, 01, 02, 03, 04, 05, 99);
 
     test('can persist date times properly', () {
       adapter.setValue(preferences, 'key', dateTime);
 
-      /// Comparing to a exact millisecond timestamp runs just fine on a local
+      /// Comparing to an exact millisecond timestamp runs just fine on a local
       /// machine, but fails in CI because of differences in geographic regions.
       ///
       /// For that reason, this test is a little fuzzy.
@@ -36,7 +45,7 @@ void main() {
       /// machine, but fails in CI because of differences in geographic regions.
       ///
       /// For that reason, this test is a little fuzzy.
-      final storedDateTime = adapter.getValue(preferences, 'key');
+      final storedDateTime = adapter.getValue(preferences, 'key')!;
       expect(
         storedDateTime.difference(dateTime) <
             const Duration(hours: 1, minutes: 1),
@@ -49,11 +58,6 @@ void main() {
 
       final storedDateTime = adapter.getValue(preferences, 'key');
       expect(storedDateTime, isNull);
-    });
-
-    test('handles persisting null datetimes gracefully', () {
-      adapter.setValue(preferences, 'key', null);
-      verify(preferences.setString('key', null));
     });
   });
 }

--- a/test/adapters/json_adapter_test.dart
+++ b/test/adapters/json_adapter_test.dart
@@ -3,11 +3,20 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 import 'package:test/test.dart';
 
-class MockSharedPreferences extends Mock implements SharedPreferences {}
+class MockSharedPreferences extends Mock implements SharedPreferences {
+  @override
+  Future<bool> setString(String? key, String? value) {
+    return super.noSuchMethod(
+      Invocation.method(#setString, [key, value]),
+      returnValue: Future.value(true),
+      returnValueForMissingStub: Future.value(true),
+    );
+  }
+}
 
 void main() {
   group('ValueAdapter tests', () {
-    MockSharedPreferences preferences;
+    late MockSharedPreferences preferences;
 
     setUp(() {
       preferences = MockSharedPreferences();
@@ -52,10 +61,10 @@ void main() {
         when(preferences.getString('key')).thenReturn('{"hello":"world"}');
 
         final adapter = JsonAdapter<TestObject>(
-          deserializer: (v) => TestObject.fromJson(v),
+          deserializer: (v) => TestObject.fromJson(v as Map<String, dynamic>),
         );
 
-        final testObject = adapter.getValue(preferences, 'key');
+        final testObject = adapter.getValue(preferences, 'key')!;
         expect(testObject.hello, 'world');
       });
 
@@ -64,9 +73,9 @@ void main() {
           serializer: (v) => {'encoded': 'value'},
         );
 
-        // What value we set here doesn't matter - we're testing that it's replaced
-        // by the value returned by serializer.
-        adapter.setValue(preferences, 'key', null);
+        // What value we set here doesn't matter - we're testing that it's
+        // replaced by the value returned by serializer.
+        adapter.setValue(preferences, 'key', TestObject(''));
         verify(preferences.setString('key', '{"encoded":"value"}'));
       });
     });

--- a/test/preference/preference_builder_test.dart
+++ b/test/preference/preference_builder_test.dart
@@ -6,32 +6,30 @@ import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
-class MockSharedPreferences extends Mock implements SharedPreferences {}
+class MockSharedPreferences extends Mock implements SharedPreferences {
+  @override
+  Future<bool> setString(String? key, String? value) {
+    return super.noSuchMethod(
+      Invocation.method(#setString, [key, value]),
+      returnValue: Future.value(true),
+      returnValueForMissingStub: Future.value(true),
+    );
+  }
+}
 
 void main() {
   group('PreferenceBuilder', () {
-    MockSharedPreferences preferences;
-    StreamController<String> keyChanges;
-    TestPreference preference;
+    late MockSharedPreferences preferences;
+    late StreamController<String> keyChanges;
+    late TestPreference preference;
 
     setUp(() {
       preferences = MockSharedPreferences();
       keyChanges = StreamController<String>();
       preference = TestPreference(preferences, keyChanges);
     });
-
-    test('passing null Preference throws an error', () {
-      expect(
-        () => PreferenceBuilder(preference: null, builder: (_, __) => null),
-        throwsA(isInstanceOf<AssertionError>()),
-      );
-    });
-
-    test('passing null PreferenceWidgetBuilder throws an error', () {
-      expect(
-        () => PreferenceBuilder(preference: preference, builder: null),
-        throwsA(isInstanceOf<AssertionError>()),
-      );
+    tearDown(() {
+      keyChanges.close();
     });
 
     testWidgets('initial build is done with current value of the preference',
@@ -84,13 +82,13 @@ void main() {
 
       // Value does not matter in a test case as the preferences are mocked.
       // This just tells the preference that something was updated.
-      preference.setValue(null);
+      preference.setValue('');
       await tester.pump();
       await tester.pump();
       expect(find.text('updated value'), findsOneWidget);
 
       when(preferences.getString('test')).thenReturn('another value');
-      preference.setValue(null);
+      preference.setValue('');
       await tester.pump();
       await tester.pump();
       expect(find.text('another value'), findsOneWidget);
@@ -111,15 +109,15 @@ void main() {
         ),
       );
 
-      preference.setValue(null);
+      preference.setValue('');
       await tester.pump();
       await tester.pump();
 
-      preference.setValue(null);
+      preference.setValue('');
       await tester.pump();
       await tester.pump();
 
-      preference.setValue(null);
+      preference.setValue('');
       await tester.pump();
       await tester.pump();
 
@@ -127,7 +125,7 @@ void main() {
 
       // So that there's no accidental lockdown because of duplicate values
       when(preferences.getString('test')).thenReturn('new value');
-      preference.setValue(null);
+      preference.setValue('');
       await tester.pump();
       await tester.pump();
       expect(find.text('new value'), findsOneWidget);

--- a/test/preference/stream_builder_and_equality_tests.dart
+++ b/test/preference/stream_builder_and_equality_tests.dart
@@ -26,12 +26,15 @@ class MockSharedPreferences extends Mock implements SharedPreferences {}
 /// good.
 void main() {
   group('StreamBuilder and equality tests', () {
-    MockSharedPreferences preferences;
-    StreamController<String> keyChanges;
+    late MockSharedPreferences preferences;
+    late StreamController<String> keyChanges;
 
     setUp(() {
       preferences = MockSharedPreferences();
       keyChanges = StreamController<String>();
+    });
+    tearDown(() {
+      keyChanges.close();
     });
 
     test('preferences with the same key and type are equal', () {


### PR DESCRIPTION
I tried to keep the methods as close to the pre-null-safe-versions as possible, though maybe some of it should be changed with regards to #3.

This migration includes a breaking change: As in the null-safe version of [<kbd>shared_preferences</kbd>](https://pub.dev/packages/shared_preferences/changelog#200), setters no longer accept `null` to mean removing values. (`remove(key)` can be used instead.)
